### PR TITLE
Add support for running Podman in the sbatch scripts

### DIFF
--- a/add-extra-containerimage.sh
+++ b/add-extra-containerimage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+if [ $# -ne 2 ]; then
+    echo "Error: Wrong number of arguments"
+    echo "Usage:"
+    echo "bash ./add-extra-containerimage.sh /path/to/where/installation-files-were-created containerimage"
+    exit 1
+fi
+
+if [ ! -d $1 ]; then
+  echo "Error: The given argument $1 is not a directory"
+  exit 1
+fi
+
+if [ ! -d $1/extra_containerimages ]; then
+  echo "Error: The extra_containerimages directory is missing"
+  exit 1
+fi
+
+if ! podman image exists $2; then
+  echo Error: containerimage does not exist in local storage. First run \"podman pull $2\"
+  exit 1
+fi
+
+dir=$(mktemp "--tmpdir=$1/extra_containerimages" -d tmpXXXX)
+
+podman save $2 > "${dir}/image.tar"
+echo $2 > "${dir}/name"

--- a/adjusting_ports_for_norouter/slurmctld/include_slurm.conf
+++ b/adjusting_ports_for_norouter/slurmctld/include_slurm.conf
@@ -1,3 +1,4 @@
 SlurmctldPort=7817
 SlurmdPort=6818
 AccountingStoragePort=6819
+SlurmctldHost=slurmctld

--- a/adjusting_ports_for_norouter/slurmd/include_slurm.conf
+++ b/adjusting_ports_for_norouter/slurmd/include_slurm.conf
@@ -1,3 +1,4 @@
 SlurmctldPort=6817
 SlurmdPort=7818
 AccountingStoragePort=6819
+SlurmctldHost=127.0.29.3

--- a/adjusting_ports_for_norouter/slurmdbd/include_slurm.conf
+++ b/adjusting_ports_for_norouter/slurmdbd/include_slurm.conf
@@ -1,3 +1,4 @@
 SlurmctldPort=6817
 SlurmdPort=6818
 AccountingStoragePort=7819
+SlurmctldHost=127.0.29.3

--- a/container/slurm-with-norouter/Dockerfile
+++ b/container/slurm-with-norouter/Dockerfile
@@ -1,5 +1,0 @@
-FROM docker.io/giovtorres/slurm-docker-cluster:latest
-RUN curl -o /usr/local/bin/norouter --fail -L https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m) && \
-    chmod 755 /usr/local/bin/norouter && \
-    chown munge:munge /var/run/munge && \
-    sed -i 's/socket=\/var\/lib\/mysql\/mysql.sock/socket=\/var\/run\/mysqld\/mysqld.sock/g' /etc/my.cnf

--- a/design.md
+++ b/design.md
@@ -1,0 +1,47 @@
+## Design details
+
+Right now it is unclear if the portmapping and
+the files under slurm-container-cluster/adjusting_ports_for_norouter/
+are really needed. It is likely that this could be simplified.
+
+The first goal was just to have a proof-of-concept to show that it
+is possible to run Slurm in containers with the help of __podman__, __norouter__, __sshfs__ and __sshocker__.
+The proof-of-concept also shows that it is possible to run `podman run` in the _sbatch_ scripts.
+To be able to do that the technique running Podman in Podman was used
+(see also https://stackoverflow.com/questions/64509618/podman-in-podman-similar-to-docker-in-docker)
+
+### Remapping port numbers
+
+`slurmdbd`, `slurmctld` and `slurmd` are all running on non-standard ports.
+ `norouter` remaps these port numbers so that they appear to be running on the
+ normal port numbers.
+ The configuration file _/etc/slurm.conf_ will differ slightly for when running `slurmdbd`, `slurmctld` and `slurmd`,
+because the value SlurmctldPort needs to be given a non-standard value when running slurmctld and
+the value SlurmdPort needs to be given a non-standard value when runnng slurmd.
+
+Slurm normally complains if the _slurm.conf_ is different. To disable this check this line was added
+```
+DebugFlags=NO_CONF_HASH
+```
+
+The adjustment of port numbers was done by removing the normal lines
+
+```
+SlurmctldPort=6817
+SlurmdPort=6818
+```
+
+from _slurm.conf_ and adding the new line
+
+```
+include adjusting_ports_for_norouter/include_slurm.conf
+```
+
+so that we can fine-tune the configuration of port-numbers by doing a bind-mount
+of one the directories
+
+* _~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmctld_
+* _~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmdbd_
+* _~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmdb_
+
+on to _/etc/slurm/adjusting_ports_for_norouter/_

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 set -e
 
-if [ "$1" = "slurmdbd" ]
+if [ "$1" = "slurmdbd" -o "$1" = "slurmctld" -o "$1" = "slurmd" ]
 then
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
+    until pgrep norouter
+    do
+        echo "-- Waiting for norouter to start. Sleeping 2 seconds ..."
+        sleep 2
+    done
+    sleep 2
+fi
 
+if [ "$1" = "slurmdbd" ]
+then
     echo "---> Starting the Slurm Database Daemon (slurmdbd) ..."
-
     {
         . /etc/slurm/slurmdbd.conf
         until echo "SELECT 1" | mysql -h $StorageHost -u$StorageUser -p$StoragePass 2>&1 > /dev/null
         do
             echo "-- Waiting for database to become active ..."
-            sleep 2
+            sleep 1
         done
     }
     echo "-- Database is now active ..."
@@ -23,16 +31,14 @@ fi
 
 if [ "$1" = "slurmctld" ]
 then
-    echo "---> Starting the MUNGE Authentication service (munged) ..."
-    gosu munge /usr/sbin/munged
-
     echo "---> Waiting for slurmdbd to become active before starting slurmctld ..."
 
     until 2>/dev/null >/dev/tcp/slurmdbd/6819
-    do
-        echo "-- slurmdbd is not available.  Sleeping ..."
-        sleep 2
-    done
+        do
+           echo "-- Waiting for slurmdbd to become active ..."
+            sleep 1
+        done
+
     echo "-- slurmdbd is now active ..."
 
     echo "---> Starting the Slurm Controller Daemon (slurmctld) ..."
@@ -41,15 +47,13 @@ fi
 
 if [ "$1" = "slurmd" ]
 then
-    echo "---> Starting the MUNGE Authentication service (munged) ..."
-    gosu munge /usr/sbin/munged
-
     echo "---> Waiting for slurmctld to become active before starting slurmd..."
 
-    until 2>/dev/null >/dev/tcp/slurmctld/6817
+
+    until 2>/dev/null >/dev/tcp/slurmctld-norouter/6817
     do
         echo "-- slurmctld is not available.  Sleeping ..."
-        sleep 2
+        sleep 1
     done
     echo "-- slurmctld is now active ..."
 

--- a/norouter.yaml
+++ b/norouter.yaml
@@ -1,47 +1,23 @@
 hosts:
-  host0:
-    vip: "127.0.29.0"
+  local:
+    vip: "127.0.29.100"
   slurmdbd:
     cmd: ["podman", "exec", "-i", "slurmdbd", "norouter"]
     vip: "127.0.29.2"
     ports: ["6819:127.0.0.1:7819"]
-  slurmctld:
+    writeEtcHosts: true
+  slurmctld-norouter:
     cmd: ["podman", "exec", "-i", "slurmctld", "norouter"]
     vip: "127.0.29.3"
     ports: ["6817:127.0.0.1:7817"]
+    writeEtcHosts: true
   c1:
     cmd: ["podman", "exec", "-i", "c1", "norouter"]
     vip: "127.0.30.1"
     ports: ["6818:127.0.0.1:7818"]
+    writeEtcHosts: true
   c2:
-    cmd: ["ssh", "remoteuser@192.0.2.10", "--", "podman", "exec", "-i", "c2", "norouter"]
+    cmd: ["ssh", "core@192.168.122.253", "--", "podman", "exec", "-i", "c2", "norouter"]
     vip: "127.0.30.2"
     ports: ["6818:127.0.0.1:7818"]
-# c3:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c3", "norouter"]
-#   vip: "127.0.30.3"
-#   ports: ["6818:127.0.0.1:7818"]
-# c4:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c4", "norouter"]
-#   vip: "127.0.30.4"
-#   ports: ["6818:127.0.0.1:7818"]
-# c5:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c5", "norouter"]
-#   vip: "127.0.30.5"
-#   ports: ["6818:127.0.0.1:7818"]
-# c6:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c6", "norouter"]
-#   vip: "127.0.30.6"
-#   ports: ["6818:127.0.0.1:7818"]
-# c7:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c7", "norouter"]
-#   vip: "127.0.30.7"
-#   ports: ["6818:127.0.0.1:7818"]
-# c8:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c8", "norouter"]
-#   vip: "127.0.30.8"
-#   ports: ["6818:127.0.0.1:7818"]
-# c9:
-#   cmd: ["ssh", "ADJUST THIS VALUE username@host", "--", "podman", "exec", "-i", "c9", "norouter"]
-#   vip: "127.0.30.9"
-#   ports: ["6818:127.0.0.1:7818"]
+    writeEtcHosts: true

--- a/prepare-installation-files.sh
+++ b/prepare-installation-files.sh
@@ -15,10 +15,14 @@ if ! podman image exists localhost/slurm-with-norouter; then
     exit 1
 fi
 
-tmpdir=$(mktemp -d)
+tmpdir=$(mktemp -d /tmp/slurm-container-cluster-installation-filesXXXX)
 chmod 700 $tmpdir
 mkdir -p $tmpdir/etc_munge
 mkdir -p $tmpdir/etc_slurm
+
+
+# Extra container images is later added with the script add-extra-containerimage.sh
+mkdir -p $tmpdir/extra_containerimages
 
 # If SELINUX is enabled let us label the files in the volume
 volumeArg=$(selinuxenabled 2> /dev/null && echo :Z || true)
@@ -34,44 +38,7 @@ podman save localhost/slurm-with-norouter > ${tmpdir}/slurm-with-norouter.tar
 
 podman run --rm --volume=${tmpdir}/etc_slurm:/target${volumeArg} localhost/slurm-with-norouter cp -r /etc/slurm/. /target
 
-sed -i 's/^StorageHost=mysql/StorageHost=localhost/' ${tmpdir}/etc_slurm/slurmdbd.conf
-
-# slurmdbd, slurmctld and slurmd are all running on non-standard ports.
-# norouter remaps these port numbers so that they appear to be running on the
-# normal port numbers.
-# The configuration file /etc/slurm.conf can't be identical for all of slurmdbd, slurmctld and slurmd,
-# because the value SlurmctldPort needs to be given a non-standard value when running slurmctld and
-# the value SlurmdPort needs to be given a non-standard value when runnng slurmd.
-# By removing the normal lines 
-#
-# SlurmctldPort=6817
-# SlurmdPort=6818
-#
-# from slurm.conf and adding the new line
-#
-# include adjusting_ports_for_norouter/include_slurm.conf
-#
-# we can fine-tune the configuration of port-numbers by doing a bind-mount
-# so that one of the directories
-# 
-# ~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmctld
-# ~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmdbd 
-# ~/.config/slurm-container-cluster/adjusting_ports_for_norouter/slurmdbd 
-#
-# is mapped to /etc/slurm/adjusting_ports_for_norouter/
-
-sed -i '/^SlurmctldPort=/d' ${tmpdir}/etc_slurm/slurm.conf
-sed -i '/^SlurmdPort=/d' ${tmpdir}/etc_slurm/slurm.conf
-
-sed -i '/^DbdPort=/d' ${tmpdir}/etc_slurm/slurmdbd.conf
-echo DbdPort=7819 >> ${tmpdir}/etc_slurm/slurmdbd.conf
-
-# The slurm configuration differs due to the use of 
-# ~/.config/slurm-container-cluster/adjusting_ports_for_norouter/
-# We need to disable the check that the configuration should be the same
-echo DebugFlags=NO_CONF_HASH >> ${tmpdir}/etc_slurm/slurm.conf
-
-echo include adjusting_ports_for_norouter/include_slurm.conf >> ${tmpdir}/etc_slurm/slurm.conf
+chmod 600 ${tmpdir}/etc_slurm/slurmdbd.conf
 
 curl -o ${tmpdir}/norouter --fail -L https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m)
 chmod +x ${tmpdir}/norouter

--- a/slurm.conf
+++ b/slurm.conf
@@ -3,15 +3,11 @@
 # See the slurm.conf man page for more information.
 #
 ClusterName=linux
-ControlMachine=slurmctld
-ControlAddr=slurmctld
 #BackupController=
 #BackupAddr=
 #
 SlurmUser=slurm
 #SlurmdUser=root
-SlurmctldPort=6817
-SlurmdPort=6818
 AuthType=auth/munge
 #JobCredentialPrivateKey=
 #JobCredentialPublicCertificate=
@@ -22,6 +18,7 @@ MpiDefault=none
 SlurmctldPidFile=/var/run/slurmd/slurmctld.pid
 SlurmdPidFile=/var/run/slurmd/slurmd.pid
 ProctrackType=proctrack/linuxproc
+TCPTimeout=20
 #PluginDir=
 CacheGroups=0
 #FirstJobId=
@@ -58,7 +55,6 @@ SchedulerType=sched/backfill
 #SchedulerRootFilter=
 SelectType=select/cons_res
 SelectTypeParameters=CR_CPU_Memory
-FastSchedule=1
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0
 #PriorityUsageResetPeriod=14-0
@@ -83,7 +79,6 @@ JobAcctGatherFrequency=30
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=slurmdbd
 AccountingStoragePort=6819
-AccountingStorageLoc=slurm_acct_db
 #AccountingStoragePass=
 #AccountingStorageUser=
 #
@@ -92,3 +87,9 @@ NodeName=c[1-2] RealMemory=1000 State=UNKNOWN
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=1 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+
+# slurm-container-cluster specific modifications
+#
+# See also: design.md
+DebugFlags=NO_CONF_HASH
+include adjusting_ports_for_norouter/include_slurm.conf

--- a/slurmdbd.conf
+++ b/slurmdbd.conf
@@ -17,8 +17,7 @@ AuthType=auth/munge
 #
 # slurmDBD info
 DbdAddr=slurmdbd
-DbdHost=slurmdbd
-#DbdPort=6819
+DbdHost=localhost
 SlurmUser=slurm
 #MessageTimeout=300
 DebugLevel=4
@@ -31,7 +30,12 @@ PidFile=/var/run/slurmdbd/slurmdbd.pid
 #
 # Database info
 StorageType=accounting_storage/mysql
-StorageHost=mysql
+StorageHost=localhost
 StorageUser=slurm
 StoragePass=password
 StorageLoc=slurm_acct_db
+
+# Modifications related to slurm-container-cluster:
+# See also: design.md
+
+DbdPort=7819

--- a/systemd/slurm-computenode@.service
+++ b/systemd/slurm-computenode@.service
@@ -19,40 +19,27 @@ StateDirectory=slurm-container-cluster
 StateDirectoryMode=0700
 ExecStartPre=rm -f %t/slurm-slurmd%i.pid %t/slurm-slurmd%i.ctr-id
 ExecStartPre=mkdir -p %S/slurm-container-cluster/computenode/%i/var_log_slurm
-ExecStartPre=/usr/bin/podman unshare chmod 700 %S/slurm-container-cluster/computenode/%i/var_log_slurm
-ExecStartPre=/usr/bin/podman unshare chown 0:0 %S/slurm-container-cluster/computenode/%i/var_log_slurm
-ExecStartPre=/usr/bin/podman unshare rm -rf %S/slurm-container-cluster/computenode/%i/var_log_munge
-ExecStartPre=mkdir -p %S/slurm-container-cluster/computenode/%i/var_log_munge
+ExecStartPre=podman unshare chmod 700 %S/slurm-container-cluster/computenode/%i/var_log_slurm
+ExecStartPre=podman unshare chown 992:991 %S/slurm-container-cluster/computenode/%i/var_log_slurm
+ExecStartPre=podman unshare rm -rf %S/slurm-container-cluster/computenode/%i/var_log_munge
+ExecStartPre=podman unshare mkdir -p %S/slurm-container-cluster/computenode/%i/var_log_munge
 ExecStartPre=/usr/bin/podman unshare chmod 755 %S/slurm-container-cluster/computenode/%i/var_log_munge
-ExecStartPre=/usr/bin/podman unshare chown 999:997 %S/slurm-container-cluster/computenode/%i/var_log_munge
-#ExecStartPre=/usr/bin/podman unshare chown 0:0 %S/slurm-container-cluster/computenode/%i/var_log_munge
-ExecStart=/usr/bin/podman run --add-host c1:127.0.30.1 \
-                              --add-host c2:127.0.30.2 \
-                              --add-host c3:127.0.30.3 \
-                              --add-host c4:127.0.30.4 \
-                              --add-host c5:127.0.30.5 \
-                              --add-host c6:127.0.30.6 \
-                              --add-host c7:127.0.30.7 \
-                              --add-host c8:127.0.30.8 \
-                              --add-host c9:127.0.30.9 \
-                              --add-host slurmctld:127.0.29.3 \
-                              --add-host slurmdbd:127.0.29.2 \
-                              --cgroups=no-conmon \
+ExecStartPre=/usr/bin/podman unshare chown 993:992 %S/slurm-container-cluster/computenode/%i/var_log_munge
+ExecStart=/usr/bin/podman run --cgroups=no-conmon \
                               --cidfile %t/slurm-slurmd%i.ctr-id \
                               --conmon-pidfile %t/slurm-slurmd%i.pid \
                               --detach \
-                              --hostname c%i \
                               --name c%i \
                               --privileged=true \
                               --replace \
                               --security-opt label=disable \
-                              --volume=%S/slurm-container-cluster/computenode/%i/var_log_slurm:/var/log/slurm:Z \
+                              --volume=%S/slurm-container-cluster/adjusting_ports_for_norouter/slurmd:/etc/slurm/adjusting_ports_for_norouter:z \
                               --volume=%S/slurm-container-cluster/computenode/%i/var_log_munge:/var/log/munge:z \
+                              --volume=%S/slurm-container-cluster/computenode/%i/var_log_slurm:/var/log/slurm:Z \
                               --volume=%S/slurm-container-cluster/etc_munge:/etc/munge:z \
                               --volume=%S/slurm-container-cluster/etc_slurm:/etc/slurm:z \
-                              --volume=%S/slurm-container-cluster/adjusting_ports_for_norouter/slurmd:/etc/slurm/adjusting_ports_for_norouter:z \
                               --volume=%S/slurm-container-cluster/slurm_jobdir:/data:slave \
-                               localhost/slurm-with-norouter slurmd
+                              localhost/slurm-with-norouter slurmd
 ExecStop=/usr/bin/podman stop --cidfile %t/slurm-slurmd%i.ctr-id \
                               --ignore \
                               --time 10

--- a/systemd/slurm-create-datadir.service
+++ b/systemd/slurm-create-datadir.service
@@ -19,12 +19,12 @@ ExecStart=/bin/mkdir -p %S/slurm-container-cluster/var_run_mysqld
 ExecStart=/bin/mkdir -p %S/slurm-container-cluster/var_log_slurmdbd
 ExecStart=/bin/mkdir -p %S/slurm-container-cluster/var_log_slurmctld
 ExecStart=podman unshare /bin/chmod 700 %S/slurm-container-cluster/etc_munge
-ExecStart=podman unshare /bin/chown 999:997 %S/slurm-container-cluster/etc_munge
+ExecStart=podman unshare /bin/chown 993:992 %S/slurm-container-cluster/etc_munge
 
 ExecStart=podman unshare /bin/chmod 700 %S/slurm-container-cluster/var_log_slurmdbd
 ExecStart=podman unshare /bin/chmod 700 %S/slurm-container-cluster/var_log_slurmctld
-ExecStart=podman unshare /bin/chown 995:995 %S/slurm-container-cluster/var_log_slurmdbd
-ExecStart=podman unshare /bin/chown 995:995 %S/slurm-container-cluster/var_log_slurmctld
+ExecStart=podman unshare /bin/chown 992:991 %S/slurm-container-cluster/var_log_slurmdbd
+ExecStart=podman unshare /bin/chown 992:991 %S/slurm-container-cluster/var_log_slurmctld
 
 KillMode=none
 

--- a/systemd/slurm-slurmctld.service
+++ b/systemd/slurm-slurmctld.service
@@ -31,23 +31,18 @@ Restart=on-failure
 StateDirectory=slurm-container-cluster
 StateDirectoryMode=0700
 ExecStartPre=/bin/rm -f %t/slurm-slurmctld.pid %t/slurm-slurmctld.ctr-id
-ExecStart=/usr/bin/podman run --add-host c1:127.0.30.1 \
-                              --add-host c2:127.0.30.2 \
-                              --add-host c3:127.0.30.3 \
-                              --add-host c4:127.0.30.4 \
-                              --add-host c5:127.0.30.5 \
-                              --add-host c6:127.0.30.6 \
-                              --add-host c7:127.0.30.7 \
-                              --add-host c8:127.0.30.8 \
-                              --add-host c9:127.0.30.9 \
-                              --add-host slurmdbd:127.0.29.2 \
+
+ExecStart=/usr/bin/podman run \
                               --cgroups=no-conmon \
                               --cidfile %t/slurm-slurmctld.ctr-id \
                               --conmon-pidfile %t/slurm-slurmctld.pid \
                               --detach \
                               --hostname slurmctld \
                               --name slurmctld \
+                              --privileged \
                               --replace \
+                              --ulimit host \
+                              --volume /dev/fuse:/dev/fuse:rw \
                               --volume=%S/slurm-container-cluster/adjusting_ports_for_norouter/slurmctld:/etc/slurm/adjusting_ports_for_norouter:z \
                               --volume=%S/slurm-container-cluster/etc_munge:/etc/munge:z \
                               --volume=%S/slurm-container-cluster/etc_slurm:/etc/slurm:z \

--- a/systemd/slurm-slurmdbd.service
+++ b/systemd/slurm-slurmdbd.service
@@ -22,21 +22,10 @@ Restart=on-failure
 StateDirectory=slurm-container-cluster
 StateDirectoryMode=0700
 ExecStartPre=/bin/rm -f %t/slurm-slurmdbd.pid %t/slurm-slurmdbd.ctr-id
-ExecStart=/usr/bin/podman run --add-host c1:127.0.30.1 \
-                              --add-host c2:127.0.30.2 \
-                              --add-host c3:127.0.30.3 \
-                              --add-host c4:127.0.30.4 \
-                              --add-host c5:127.0.30.5 \
-                              --add-host c6:127.0.30.6 \
-                              --add-host c7:127.0.30.7 \
-                              --add-host c8:127.0.30.8 \
-                              --add-host c9:127.0.30.9 \
-                              --add-host slurmctld:127.0.29.3 \
-                              --cgroups=no-conmon \
+ExecStart=/usr/bin/podman run --cgroups=no-conmon \
                               --cidfile %t/slurm-slurmdbd.ctr-id \
                               --conmon-pidfile %t/slurm-slurmdbd.pid \
                               --detach \
-                              --hostname slurmdbd \
                               --name slurmdbd \
                               --replace \
                               --volume=%S/slurm-container-cluster/adjusting_ports_for_norouter/slurmdbd:/etc/slurm/adjusting_ports_for_norouter:z \
@@ -44,7 +33,7 @@ ExecStart=/usr/bin/podman run --add-host c1:127.0.30.1 \
                               --volume=%S/slurm-container-cluster/etc_slurm:/etc/slurm:z \
                               --volume=%S/slurm-container-cluster/var_log_slurmdbd:/var/log/slurm:Z \
                               --volume=%S/slurm-container-cluster/var_run_mysqld:/var/run/mysqld:z \
-                              -e MYSQL_UNIX_PORT=/var/run/mysqld/mysqld.sock \
+                              --env MYSQL_UNIX_PORT=/var/run/mysqld/mysqld.sock \
                               localhost/slurm-with-norouter slurmdbd
 ExecStop=/usr/bin/podman stop --cidfile %t/slurm-slurmdbd.ctr-id \
                               --ignore \


### PR DESCRIPTION
Add support for adding container images to the $installation_files_dir.
These container images can after the installation be used by
Podman when it is run in Sbatch scripts.

To make this work Podman needs to be run from within Podman. See also
https://stackoverflow.com/questions/64509618/podman-in-podman-similar-to-docker-in-docker

At the moment the code is more of a proof-of-concept.
Add the file desing.md to describe the design a bit more.
It is likely that the portmapping and files under adjusting_ports_for_norouter/
could be simplified and maybe even removed.

The base image of the Dockerfile has been changed to
quay.io/podman/stable:v2.1.1
that is based on Fedora 33

Fixes: #1

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>